### PR TITLE
Optimization: no need to burn the attestation with a clever choice of context

### DIFF
--- a/src/editions/SingleBatchEditionFactory.sol
+++ b/src/editions/SingleBatchEditionFactory.sol
@@ -88,8 +88,8 @@ contract SingleBatchEditionFactory {
     {
         address creator = signedAttestation.attestation.beneficiary;
 
-        bytes32 salt = keccak256(abi.encodePacked(creator, data.name, data.animationUrl, data.imageUrl));
-        address predicted = address(getEditionAtId(uint256(salt)));
+        uint256 editionId = getEditionId(abi.encodePacked(creator, data.name, data.animationUrl, data.imageUrl), creator);
+        address predicted = address(getEditionAtId(editionId));
         validateAttestation(signedAttestation, predicted);
 
         // avoid burning all available gas if an edition already exists at this address

--- a/src/editions/interfaces/Errors.sol
+++ b/src/editions/interfaces/Errors.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
+error AddressMismatch(address expected, address actual);
 error DuplicateEdition(address);
 error InvalidBatch();
 error InvalidTimeLimit(uint256 offsetSeconds);


### PR DESCRIPTION
Another thing we discussed on the call @jorgeavaldez and @maxmux-xyz:
- the createEdition call in SingleBatchEditionFactory now expects an attestion with `context = futureEditionAddress`
- we talked about deriving it from the salt/edition id, but this feels cleaner, and the future edition address is indeed derived from the salt/edition id
- I added getters to make this easier to compute off chain: `getEditionId`, to complement `getEditionAtId`

As a result, the attestation is no longer reusable, we no longer need to burn the nonce, which means `validateAttestation` is a view function, which means I can expose it as `public` so if you want you can also call it to validate the attestation off chain 👌