### PR TITLE
Make the edition factory agnostic about the base edition impl address

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,7 @@ force = false
 # The verbosity of tests
 verbosity = 3
 
-solc_version = '0.8.17'
+solc_version = '0.8.18'
 optimizer = true
 optimizer_runs = 1000000
 via_ir = true

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,4 +4,4 @@
 forge-std/=lib/forge-std/src/
 nft-editions/=lib/nft-editions/contracts
 operator-filter-registry/=lib/nft-editions/lib/operator-filter-registry/src/
-
+SS2ERC721/=lib/nft-editions/lib/SS2ERC721/src/

--- a/script/SingleBatchEditionDemo.s.sol
+++ b/script/SingleBatchEditionDemo.s.sol
@@ -50,7 +50,6 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
         bytes memory recipients = Addresses.make(1000);
 
         EditionData memory editionData = EditionData({
-            editionImpl: SINGLE_BATCH_EDITION_IMPL,
             // quotes will need to be escaped:
             name: unicode'"She gets visions" 👁️',
             // newlines will need to be escaped
@@ -67,6 +66,7 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
 
         address editionAddress = address(
             editionFactory.createEdition(
+                SINGLE_BATCH_EDITION_IMPL,
                 editionData,
                 recipients,
                 signedAttestation

--- a/script/SingleBatchEditionDemo.s.sol
+++ b/script/SingleBatchEditionDemo.s.sol
@@ -9,7 +9,7 @@ import {Addresses} from "nft-editions/utils/Addresses.sol";
 
 import {ShowtimeVerifier} from "src/ShowtimeVerifier.sol";
 import {IShowtimeVerifier, Attestation, SignedAttestation} from "src/interfaces/IShowtimeVerifier.sol";
-import {SingleBatchEditionFactory, EditionData} from "src/editions/SingleBatchEditionFactory.sol";
+import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
 
 import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol";
 
@@ -24,7 +24,7 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
 
         vm.startBroadcast(pk);
 
-        SingleBatchEditionFactory editionFactory = new SingleBatchEditionFactory(VERIFIER);
+        EditionFactory editionFactory = new EditionFactory(VERIFIER);
 
         address creator = 0x9cc97852491fBB3B63c539f6C20Eb24A1c76568f;
 

--- a/script/SingleBatchEditionDemo.s.sol
+++ b/script/SingleBatchEditionDemo.s.sol
@@ -24,10 +24,7 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
 
         vm.startBroadcast(pk);
 
-        SingleBatchEditionFactory editionFactory = new SingleBatchEditionFactory(
-            SINGLE_BATCH_EDITION_IMPL,
-            VERIFIER
-        );
+        SingleBatchEditionFactory editionFactory = new SingleBatchEditionFactory(VERIFIER);
 
         address creator = 0x9cc97852491fBB3B63c539f6C20Eb24A1c76568f;
 
@@ -53,6 +50,7 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
         bytes memory recipients = Addresses.make(1000);
 
         EditionData memory editionData = EditionData({
+            editionImpl: SINGLE_BATCH_EDITION_IMPL,
             // quotes will need to be escaped:
             name: unicode'"She gets visions" 👁️',
             // newlines will need to be escaped
@@ -80,7 +78,7 @@ contract SingleBatchEditionDemo is Script, ShowtimeVerifierFixture {
         vm.stopBroadcast();
     }
 
-    function getVerifier() public view override returns (ShowtimeVerifier) {
+    function getVerifier() public pure override returns (ShowtimeVerifier) {
         return ShowtimeVerifier(VERIFIER);
     }
 

--- a/script/SingleBatchEditions.s.sol
+++ b/script/SingleBatchEditions.s.sol
@@ -6,7 +6,7 @@ import {Script, console2} from "forge-std/Script.sol";
 import {SingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
 
 import {IShowtimeVerifier, Attestation, SignedAttestation} from "src/interfaces/IShowtimeVerifier.sol";
-import {SingleBatchEditionFactory} from "src/editions/SingleBatchEditionFactory.sol";
+import {EditionFactory} from "src/editions/EditionFactory.sol";
 
 contract SingleBatchEditions is Script {
     address public constant SHOWTIME_VERIFIER = 0x50C0017836517dc49C9EBC7615d8B322A0f91F67;
@@ -20,7 +20,7 @@ contract SingleBatchEditions is Script {
         SingleBatchEdition editionImpl = new SingleBatchEdition{ salt: 0 }();
         console2.log("editionImpl:", address(editionImpl));
 
-        SingleBatchEditionFactory factory = new SingleBatchEditionFactory{ salt: 0 }(SHOWTIME_VERIFIER);
+        EditionFactory factory = new EditionFactory{ salt: 0 }(SHOWTIME_VERIFIER);
         console2.log("factory:", address(factory));
     }
 }

--- a/script/SingleBatchEditions.s.sol
+++ b/script/SingleBatchEditions.s.sol
@@ -20,11 +20,7 @@ contract SingleBatchEditions is Script {
         SingleBatchEdition editionImpl = new SingleBatchEdition{ salt: 0 }();
         console2.log("editionImpl:", address(editionImpl));
 
-        SingleBatchEditionFactory factory = new SingleBatchEditionFactory{ salt: 0 }(
-            address(editionImpl),
-            SHOWTIME_VERIFIER
-        );
-
+        SingleBatchEditionFactory factory = new SingleBatchEditionFactory{ salt: 0 }(SHOWTIME_VERIFIER);
         console2.log("factory:", address(factory));
     }
 }

--- a/src/editions/EditionFactory.sol
+++ b/src/editions/EditionFactory.sol
@@ -82,12 +82,10 @@ contract EditionFactory {
         returns (ISingleBatchEdition edition)
     {
         address editionImpl = data.editionImpl;
-        if (editionImpl == address(0)) {
-            revert NullAddress();
-        }
-
         address creator = signedAttestation.attestation.beneficiary;
         uint256 editionId = getEditionId(data, creator);
+
+        // we expect this to revert if editionImpl is null
         address predicted = address(getEditionAtId(editionImpl, editionId));
         validateAttestation(signedAttestation, predicted);
 
@@ -134,6 +132,10 @@ contract EditionFactory {
     }
 
     function getEditionAtId(address editionImpl, uint256 editionId) public view returns (ISingleBatchEdition) {
+        if (editionImpl == address(0)) {
+            revert NullAddress();
+        }
+
         return ISingleBatchEdition(
             ClonesUpgradeable.predictDeterministicAddress(editionImpl, bytes32(editionId), address(this))
         );

--- a/src/editions/EditionFactory.sol
+++ b/src/editions/EditionFactory.sol
@@ -37,7 +37,7 @@ struct EditionData {
     string tags;
 }
 
-contract SingleBatchEditionFactory {
+contract EditionFactory {
     /// @dev we expect tags to be a comma-separated list of strings e.g. "music,location,password"
     event CreatedBatchEdition(
         uint256 indexed editionId, address indexed creator, address editionContractAddress, string tags

--- a/test/editions/EditionFactoryTest.sol
+++ b/test/editions/EditionFactoryTest.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+import {SingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
+import {Test} from "lib/forge-std/src/Test.sol";
+import "nft-editions/interfaces/Errors.sol";
+
+import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
+import {EditionFactoryFixture} from "test/fixtures/EditionFactoryFixture.sol";
+import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol";
+import "src/editions/interfaces/Errors.sol";
+
+contract EditionFactoryTest is Test, ShowtimeVerifierFixture, EditionFactoryFixture {
+
+    function setUp() public {
+        __EditionFactoryFixture_setUp();
+    }
+
+    function test_createEdition_nullEditionImplReverts() public {
+        EditionData memory editionData = DEFAULT_EDITION_DATA;
+        editionData.editionImpl = address(0);
+
+        uint256 editionId = editionFactory.getEditionId(editionData, creator);
+
+        vm.expectRevert(NullAddress.selector);
+        editionFactory.getEditionAtId(editionData.editionImpl, editionId);
+    }
+}

--- a/test/editions/EditionFactoryTest.sol
+++ b/test/editions/EditionFactoryTest.sol
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import {SingleBatchEdition, ISingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
+import {SingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
 import {Test} from "lib/forge-std/src/Test.sol";
 import "nft-editions/interfaces/Errors.sol";
 
 import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
 import {EditionFactoryFixture} from "test/fixtures/EditionFactoryFixture.sol";
-import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol";
+import {MockBatchEdition} from "test/fixtures/MockBatchEdition.sol";
+import {ShowtimeVerifierFixture, Attestation, SignedAttestation} from "test/fixtures/ShowtimeVerifierFixture.sol";
 import "src/editions/interfaces/Errors.sol";
 
-// contract MockBatchEdition is ISingle
 
 contract EditionFactoryTest is Test, ShowtimeVerifierFixture, EditionFactoryFixture {
-
     function setUp() public {
         __EditionFactoryFixture_setUp();
     }
@@ -25,5 +24,64 @@ contract EditionFactoryTest is Test, ShowtimeVerifierFixture, EditionFactoryFixt
         editionFactory.getEditionAtId(address(0), editionId);
     }
 
+    // test that changing the edition impl changes the predicted address
+    function test_getEditionAtId_differentEditionImpls() public {
+        uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creator);
 
+        address edition1 = address(editionFactory.getEditionAtId(SINGLE_BATCH_EDITION_IMPL, editionId));
+        address edition2 = address(editionFactory.getEditionAtId(address(new SingleBatchEdition()), editionId));
+
+        assertFalse(edition1 == edition2);
+    }
+
+    // test that changing the edition impl changes the actual address after createEdition
+    function test_createEdition_differentEditionImpls() public {
+        address altEditionImpl = address(new SingleBatchEdition());
+        Attestation memory altAttestation = getCreatorAttestation(altEditionImpl, DEFAULT_EDITION_DATA, creator);
+        SignedAttestation memory altSignedAttestation = signed(signerKey, altAttestation);
+
+        bytes memory recipients = abi.encodePacked(address(this));
+
+        address edition1 = address(createEdition(getCreatorAttestation(), recipients));
+        address edition2 = address(createEdition(altEditionImpl, altSignedAttestation, recipients, ""));
+
+        assertFalse(edition1 == edition2);
+    }
+
+    // test that we can't reuse a signed attestation with a different edition impl
+    function test_createEdition_canNotReuseSignedAttestation() public {
+        // a hijacker wants to lift a signed attestation and use it for a different impl address
+        address altEditionImpl = address(new SingleBatchEdition());
+        bytes memory recipients = abi.encodePacked(address(this));
+        SignedAttestation memory ogAttestation = signed(signerKey, getCreatorAttestation());
+
+        uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creator);
+        address hijackedAddr = address(editionFactory.getEditionAtId(altEditionImpl, editionId));
+
+        // the creator can create an edition with the original attestation, but a hijacker can not
+        // the error says "this attestation is only valid for the original address, not for the hijacked address"
+        createEdition(
+            altEditionImpl,
+            ogAttestation,
+            recipients,
+            abi.encodeWithSignature(
+                "AddressMismatch(address,address)",
+                hijackedAddr,
+                ogAttestation.attestation.context
+            )
+        );
+    }
+
+    function test_createEdition_canCreateAlternateContract() public {
+        address altEditionImpl = address(new MockBatchEdition());
+
+        SingleBatchEdition edition = createEdition(
+            altEditionImpl,
+            signed(signerKey, getCreatorAttestation(altEditionImpl, DEFAULT_EDITION_DATA, creator)),
+            "",
+            ""
+        );
+
+        assertEq(edition.contractURI(), "mock");
+    }
 }

--- a/test/editions/EditionFactoryTest.sol
+++ b/test/editions/EditionFactoryTest.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.7;
 
-import {SingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
+import {SingleBatchEdition, ISingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
 import {Test} from "lib/forge-std/src/Test.sol";
 import "nft-editions/interfaces/Errors.sol";
 
@@ -10,6 +10,8 @@ import {EditionFactoryFixture} from "test/fixtures/EditionFactoryFixture.sol";
 import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol";
 import "src/editions/interfaces/Errors.sol";
 
+// contract MockBatchEdition is ISingle
+
 contract EditionFactoryTest is Test, ShowtimeVerifierFixture, EditionFactoryFixture {
 
     function setUp() public {
@@ -17,12 +19,11 @@ contract EditionFactoryTest is Test, ShowtimeVerifierFixture, EditionFactoryFixt
     }
 
     function test_createEdition_nullEditionImplReverts() public {
-        EditionData memory editionData = DEFAULT_EDITION_DATA;
-        editionData.editionImpl = address(0);
-
-        uint256 editionId = editionFactory.getEditionId(editionData, creator);
+        uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creator);
 
         vm.expectRevert(NullAddress.selector);
-        editionFactory.getEditionAtId(editionData.editionImpl, editionId);
+        editionFactory.getEditionAtId(address(0), editionId);
     }
+
+
 }

--- a/test/editions/SingleBatchEditionTest.sol
+++ b/test/editions/SingleBatchEditionTest.sol
@@ -125,13 +125,13 @@ contract SingleBatchEditionTest is Test, EditionFactoryFixture {
         vm.prank(address(editionFactory));
 
         // second one should fail
-        vm.expectRevert(SoldOut.selector);
+        vm.expectRevert("ALREADY_MINTED");
         edition.mintBatch(abi.encodePacked(claimer));
     }
 
     function testEmptyBatchMint() public {
         // when we mint a batch with no claimers, it fails with InvalidBatch()
-        createEdition(getCreatorAttestation(), "", abi.encodeWithSignature("InvalidBatch()"));
+        createEdition(getCreatorAttestation(), "", "INVALID_ADDRESSES");
     }
 
     function testBatchMintWithDuplicateClaimer() public {

--- a/test/editions/SingleBatchEditionTest.sol
+++ b/test/editions/SingleBatchEditionTest.sol
@@ -30,7 +30,7 @@ contract SingleBatchEditionTest is Test, EditionFactoryFixture {
 
     function testCreateEditionHappyPath() public {
         uint256 id = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creator);
-        address expectedAddr = address(editionFactory.getEditionAtId(DEFAULT_EDITION_DATA.editionImpl, id));
+        address expectedAddr = address(editionFactory.getEditionAtId(SINGLE_BATCH_EDITION_IMPL, id));
 
         // the edition creator emits the expected event
         vm.expectEmit(true, true, true, true);
@@ -104,7 +104,7 @@ contract SingleBatchEditionTest is Test, EditionFactoryFixture {
 
         address expectedAddr = address(
             editionFactory.getEditionAtId(
-                DEFAULT_EDITION_DATA.editionImpl,
+                SINGLE_BATCH_EDITION_IMPL,
                 editionFactory.getEditionId(DEFAULT_EDITION_DATA, badActor)));
 
         // it does not work

--- a/test/editions/SingleBatchEditionTest.sol
+++ b/test/editions/SingleBatchEditionTest.sol
@@ -7,102 +7,21 @@ import {Test} from "lib/forge-std/src/Test.sol";
 import "nft-editions/interfaces/Errors.sol";
 import {SSTORE2} from "solmate/utils/SSTORE2.sol";
 
-import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
-import "test/fixtures/ShowtimeVerifierFixture.sol";
+// import {Attestation, SignedAttestation} from "src/interfaces/IShowtimeVerifier.sol";
+
+import "test/fixtures/EditionFactoryFixture.sol";
 import "src/editions/interfaces/Errors.sol";
 
-contract SingleBatchEditionTest is Test, ShowtimeVerifierFixture {
+contract SingleBatchEditionTest is Test, EditionFactoryFixture {
     event CreatedBatchEdition(
         uint256 indexed editionId, address indexed creator, address editionContractAddress, string tags
     );
 
-    uint256 constant ROYALTY_BPS = 1000;
-    EditionData private DEFAULT_EDITION_DATA = EditionData(
-        address(new SingleBatchEdition()),
-        "name",
-        "description",
-        "animationUrl",
-        "imageUrl",
-        ROYALTY_BPS,
-        "externalUrl",
-        "creatorName",
-        "tag1,tag2"
-    );
-
-    EditionFactory editionFactory;
-    ShowtimeVerifier verifier;
-
-    address creator = makeAddr("creator");
-    address relayer = makeAddr("relayer");
-    address verifierOwner = makeAddr("verifierOwner");
     address claimer = makeAddr("claimer");
     address badActor = makeAddr("badActor");
-    address signerAddr;
-    uint256 signerKey;
 
     function setUp() public {
-        // configure verifier
-        verifier = new ShowtimeVerifier(verifierOwner);
-        (signerAddr, signerKey) = makeAddrAndKey("signer");
-        vm.prank(verifierOwner);
-        verifier.registerSigner(signerAddr, 7);
-
-        // configure editionFactory
-        editionFactory = new EditionFactory(address(verifier));
-    }
-
-    function getVerifier() public view override returns (ShowtimeVerifier) {
-        return verifier;
-    }
-
-    function createEdition(SignedAttestation memory signedAttestation, bytes memory recipients, bytes memory expectedError)
-        public
-        returns (SingleBatchEdition newEdition)
-    {
-        // anyone can broadcast the transaction as long as it has the right signed attestation
-        vm.prank(relayer);
-
-        if (expectedError.length > 0) {
-            vm.expectRevert(expectedError);
-        }
-
-        newEdition = SingleBatchEdition(
-            address(
-                editionFactory.createEdition(
-                    DEFAULT_EDITION_DATA,
-                    recipients,
-                    signedAttestation
-                )
-            )
-        );
-    }
-
-    function createEdition(Attestation memory attestation, bytes memory recipients, bytes memory expectedError)
-        public
-        returns (SingleBatchEdition)
-    {
-        return createEdition(signed(signerKey, attestation), recipients, expectedError);
-    }
-
-    function createEdition(Attestation memory attestation, bytes memory recipients) public returns (SingleBatchEdition) {
-        return createEdition(attestation, recipients, "");
-    }
-
-    function getCreatorAttestation() public view returns (Attestation memory creatorAttestation) {
-        return getCreatorAttestation(creator);
-    }
-
-    function getCreatorAttestation(address creatorAddr) public view returns (Attestation memory creatorAttestation) {
-        // generate a valid attestation for the default edition data
-        uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creatorAddr);
-        address editionAddr = address(editionFactory.getEditionAtId(DEFAULT_EDITION_DATA.editionImpl, editionId));
-
-        creatorAttestation = Attestation({
-            context: editionAddr,
-            beneficiary: creatorAddr,
-            validUntil: block.timestamp + 2 minutes,
-            nonce: verifier.nonces(creator)
-        });
+        __EditionFactoryFixture_setUp();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/editions/SingleBatchEditionTest.sol
+++ b/test/editions/SingleBatchEditionTest.sol
@@ -7,7 +7,7 @@ import {Test} from "lib/forge-std/src/Test.sol";
 import "nft-editions/interfaces/Errors.sol";
 import {SSTORE2} from "solmate/utils/SSTORE2.sol";
 
-import {SingleBatchEditionFactory, EditionData} from "src/editions/SingleBatchEditionFactory.sol";
+import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
 import "test/fixtures/ShowtimeVerifierFixture.sol";
 import "src/editions/interfaces/Errors.sol";
 
@@ -29,7 +29,7 @@ contract SingleBatchEditionTest is Test, ShowtimeVerifierFixture {
         "tag1,tag2"
     );
 
-    SingleBatchEditionFactory editionFactory;
+    EditionFactory editionFactory;
     ShowtimeVerifier verifier;
 
     address creator = makeAddr("creator");
@@ -48,7 +48,7 @@ contract SingleBatchEditionTest is Test, ShowtimeVerifierFixture {
         verifier.registerSigner(signerAddr, 7);
 
         // configure editionFactory
-        editionFactory = new SingleBatchEditionFactory(address(verifier));
+        editionFactory = new EditionFactory(address(verifier));
     }
 
     function getVerifier() public view override returns (ShowtimeVerifier) {

--- a/test/fixtures/EditionFactoryFixture.sol
+++ b/test/fixtures/EditionFactoryFixture.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.7;
+
+import {Test} from "forge-std/Test.sol";
+
+import {SingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
+
+import {Attestation, SignedAttestation} from "src/interfaces/IShowtimeVerifier.sol";
+import {EditionFactory, EditionData} from "src/editions/EditionFactory.sol";
+import {ShowtimeVerifier} from "src/ShowtimeVerifier.sol";
+
+import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol";
+
+
+contract EditionFactoryFixture is Test, ShowtimeVerifierFixture {
+    uint256 internal constant ROYALTY_BPS = 1000;
+    EditionData internal DEFAULT_EDITION_DATA = EditionData(
+        address(new SingleBatchEdition()),
+        "name",
+        "description",
+        "animationUrl",
+        "imageUrl",
+        ROYALTY_BPS,
+        "externalUrl",
+        "creatorName",
+        "tag1,tag2"
+    );
+
+    EditionFactory internal editionFactory;
+    ShowtimeVerifier internal verifier;
+
+    address creator = makeAddr("creator");
+    address relayer = makeAddr("relayer");
+    address verifierOwner = makeAddr("verifierOwner");
+    address signerAddr;
+    uint256 signerKey;
+
+
+    function __EditionFactoryFixture_setUp() internal {
+        // configure verifier
+        verifier = new ShowtimeVerifier(verifierOwner);
+        (signerAddr, signerKey) = makeAddrAndKey("signer");
+        vm.prank(verifierOwner);
+        verifier.registerSigner(signerAddr, 7);
+
+        // configure editionFactory
+        editionFactory = new EditionFactory(address(verifier));
+    }
+
+    function getVerifier() public view override returns (ShowtimeVerifier) {
+        return verifier;
+    }
+
+    function createEdition(SignedAttestation memory signedAttestation, bytes memory recipients, bytes memory expectedError)
+        public
+        returns (SingleBatchEdition newEdition)
+    {
+        // anyone can broadcast the transaction as long as it has the right signed attestation
+        vm.prank(relayer);
+
+        if (expectedError.length > 0) {
+            vm.expectRevert(expectedError);
+        }
+
+        newEdition = SingleBatchEdition(
+            address(
+                editionFactory.createEdition(
+                    DEFAULT_EDITION_DATA,
+                    recipients,
+                    signedAttestation
+                )
+            )
+        );
+    }
+
+    function createEdition(Attestation memory attestation, bytes memory recipients, bytes memory expectedError)
+        public
+        returns (SingleBatchEdition)
+    {
+        return createEdition(signed(signerKey, attestation), recipients, expectedError);
+    }
+
+    function createEdition(Attestation memory attestation, bytes memory recipients) public returns (SingleBatchEdition) {
+        return createEdition(attestation, recipients, "");
+    }
+
+    function getCreatorAttestation() public view returns (Attestation memory creatorAttestation) {
+        return getCreatorAttestation(creator);
+    }
+
+    function getCreatorAttestation(address creatorAddr) public view returns (Attestation memory creatorAttestation) {
+        // generate a valid attestation for the default edition data
+        uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creatorAddr);
+        address editionAddr = address(editionFactory.getEditionAtId(DEFAULT_EDITION_DATA.editionImpl, editionId));
+
+        creatorAttestation = Attestation({
+            context: editionAddr,
+            beneficiary: creatorAddr,
+            validUntil: block.timestamp + 2 minutes,
+            nonce: verifier.nonces(creator)
+        });
+    }
+}

--- a/test/fixtures/EditionFactoryFixture.sol
+++ b/test/fixtures/EditionFactoryFixture.sol
@@ -14,8 +14,8 @@ import {ShowtimeVerifierFixture} from "test/fixtures/ShowtimeVerifierFixture.sol
 
 contract EditionFactoryFixture is Test, ShowtimeVerifierFixture {
     uint256 internal constant ROYALTY_BPS = 1000;
+    address internal immutable SINGLE_BATCH_EDITION_IMPL = address(new SingleBatchEdition());
     EditionData internal DEFAULT_EDITION_DATA = EditionData(
-        address(new SingleBatchEdition()),
         "name",
         "description",
         "animationUrl",
@@ -65,6 +65,7 @@ contract EditionFactoryFixture is Test, ShowtimeVerifierFixture {
         newEdition = SingleBatchEdition(
             address(
                 editionFactory.createEdition(
+                    SINGLE_BATCH_EDITION_IMPL,
                     DEFAULT_EDITION_DATA,
                     recipients,
                     signedAttestation
@@ -91,7 +92,7 @@ contract EditionFactoryFixture is Test, ShowtimeVerifierFixture {
     function getCreatorAttestation(address creatorAddr) public view returns (Attestation memory creatorAttestation) {
         // generate a valid attestation for the default edition data
         uint256 editionId = editionFactory.getEditionId(DEFAULT_EDITION_DATA, creatorAddr);
-        address editionAddr = address(editionFactory.getEditionAtId(DEFAULT_EDITION_DATA.editionImpl, editionId));
+        address editionAddr = address(editionFactory.getEditionAtId(SINGLE_BATCH_EDITION_IMPL, editionId));
 
         creatorAttestation = Attestation({
             context: editionAddr,

--- a/test/fixtures/MockBatchEdition.sol
+++ b/test/fixtures/MockBatchEdition.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import {ISingleBatchEdition} from "nft-editions/SingleBatchEdition.sol";
+
+contract MockBatchEdition is ISingleBatchEdition {
+    function contractURI() external pure returns (string memory) {
+        return "mock";
+    }
+
+    function getPrimaryOwnersPointer() external pure returns(address) {
+        return address(0);
+    }
+
+    function initialize(
+        address _owner,
+        string calldata _name,
+        string calldata _symbol,
+        string calldata _description,
+        string calldata _animationUrl,
+        string calldata _imageUrl,
+        uint256 _royaltyBPS,
+        address _minter
+    ) external {
+        // mockedy mock mock
+    }
+
+    function isPrimaryOwner(address tokenOwner) external pure returns(bool) {
+        return false;
+    }
+
+    function mintBatch(bytes calldata addresses) external returns (uint256) {
+        // mockedy mock mock
+    }
+
+    function mintBatch(address pointer) external returns (uint256) {
+        // mockedy mock mock
+    }
+
+    function setExternalUrl(string calldata _externalUrl) external {
+        // mockedy mock mock
+    }
+
+    function setStringProperties(
+        string[] calldata names,
+        string[] calldata values
+    ) external {
+        // mockedy mock mock
+    }
+
+    function totalSupply() external pure returns (uint256) {
+        return 0;
+    }
+
+    function withdraw() external {
+        // mockedy mock mock
+    }
+
+    function transferOwnership(address newOwner) external {
+        // mockedy mock mock
+    }
+}


### PR DESCRIPTION
May need further cleanup / documentation / renaming, but as a baseline this works.

- no longer pass a static editionImpl to the SingleBatchEditionFactory constructor
- add an editionImpl field to EditionData
- this means we accept an arbitrary editionImpl on every createEdition call

TODO:
* ~SingleBatchEditionFactory -> EditionFactory~
* ~test that can't create an edition with impl 0~
* ~test that changing the edition impl changes the signature and edition address~
* ~test that using a different impl address does change the behavior~